### PR TITLE
Specify VarjoHMD prioirty in engine config

### DIFF
--- a/VarjoSample/Config/DefaultEngine.ini
+++ b/VarjoSample/Config/DefaultEngine.ini
@@ -50,6 +50,9 @@ SpatializationPlugin=
 ReverbPlugin=
 OcclusionPlugin=
 
+[HMDPluginPriority]
+VarjoHMD=15
+
 [/Script/Engine.PhysicsSettings]
 DefaultGravityZ=-980.000000
 DefaultTerminalVelocity=4000.000000


### PR DESCRIPTION
Specify VarjoHMD priority higher than SteamVR(=10). This is needed for default Unreal Engine installations + Varjo plugin from Marketplace.